### PR TITLE
fix: #GSD-242 trivial change to trigger re-deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,4 @@ If you face issues installing the `grpc` dependency locally (required by this pr
 
 ## Contributors
 [See contributors](https://github.com/gnosis/safe-transaction-service/graphs/contributors)
+


### PR DESCRIPTION
### What was wrong?

Closes #

### How was it fixed?

@gnosis/safe-services
